### PR TITLE
update wait scripts to use internal metadata values

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@rightscale.com'
 license          'All rights reserved'
 description      'Rackspace cloud utilities'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 depends "fog"
 depends "marker"

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ depends "fog"
 depends "marker"
 
 recipe "rackspace_cloud::default", "sets up fog"
-recipe "rackspace_cloud::wait_for_rackconnect",
+recipe "rackspace_cloud::wait_for_rackspace",
   "Wait for the RackConnect automation to avoid a yum install conflict"
   
 attribute "rackspace_cloud/region",
@@ -21,5 +21,5 @@ attribute "rackspace_cloud/region",
   :required => "optional",
   :default => "ORD (Chicago)",
   :choice => ["ORD (Chicago)", "DFW (Dallas/Ft. Worth)", "IAD (Northern Virginia)", "LON (London)", "SYD (Sydney)", "HKG (Hong Kong)"],
-  :recipes => [ "rackspace_cloud::wait_for_rackconnect" ]
+  :recipes => [ "rackspace_cloud::wait_for_rackspace" ]
   

--- a/recipes/wait_for_rackspace.rb
+++ b/recipes/wait_for_rackspace.rb
@@ -24,7 +24,7 @@ log "wait_for_rackspace logs are found in /var/log/wait_for_rackspace.log"
   fi >> $log_file 2>&1
 
   # check if the server is set to be rackconnected
-  if expr "$(xenstore-read vm-data/provider_data/roles)" : "rack_connect"; then
+  if expr "$(xenstore-read vm-data/provider_data/roles)" : ".*rack_connect.*" 2>&1 >/dev/null; then
     # wait until the rackspace post install boot sequence has completed
     checkstatus(){ xenstore-read vm-data/user-metadata/rackconnect_automation_status;}
     STATUS=$(checkstatus)
@@ -38,7 +38,7 @@ log "wait_for_rackspace logs are found in /var/log/wait_for_rackspace.log"
   fi >> $log_file 2>&1
 
   # check if the server is managed operations
-  if expr "$(xenstore-read vm-data/provider_data/roles)" : "rax_managed"; then
+  if expr "$(xenstore-read vm-data/provider_data/roles)" : ".*rax_managed.*" 2>&1 >/dev/null; then
     # check for rax_service_level_automation
     checkstatus(){ xenstore-read vm-data/user-metadata/rax_service_level_automation;}
     STATUS=$(checkstatus)

--- a/recipes/wait_for_rackspace.rb
+++ b/recipes/wait_for_rackspace.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: rackspace_cloud
+# Recipe:: default
+#
+# Copyright 2014, RightScale
+#
+# All rights reserved - Do Not Redistribute
+#
+
+rightscale_marker :begin
+
+log "wait_for_rackspace logs are found in /var/log/wait_for_rackspace.log"
+
+# Need to run this in the compile phase, hence the system call
+%x[
+  log_file="/var/log/wait_for_rackspace.log"
+  if [ -d "/etc/rackspace" ]; then
+    touch /root/.noupdate
+    touch /etc/rackspace/.bootstrapped
+    touch /etc/rackspace/.noupdates
+
+    echo "*** /root/rackconnectuserconfig.log contains:"
+    cat /root/rackconnectuserconfig.log
+  fi >> $log_file 2>&1
+
+  # check if the server is set to be rackconnected
+  if expr "$(xenstore-read vm-data/provider_data/roles)" : "rack_connect"; then
+    # wait until the rackspace post install boot sequence has completed
+    checkstatus(){ xenstore-read vm-data/user-metadata/rackconnect_automation_status;}
+    STATUS=$(checkstatus)
+    echo "*** current rackconnect status: $STATUS"
+    while  [ "$STATUS" != "DEPLOYED" ]; do
+      echo '*** waiting for rackconnect post boot scripts to complete'
+      echo "*** current status: $STATUS"
+      sleep 10
+      STATUS=$(checkstatus)
+    done
+  fi >> $log_file 2>&1
+
+  # check if the server is managed operations
+  if expr "$(xenstore-read vm-data/provider_data/roles)" : "rax_managed"; then
+    # check for rax_service_level_automation
+    checkstatus(){ xenstore-read vm-data/user-metadata/rax_service_level_automation;}
+    STATUS=$(checkstatus)
+    echo "*** current managed status: $STATUS"
+    while [ "$STATUS" != "Complete" ]; do
+      echo '*** waiting for rackspace post install to complete'
+      echo "*** current status: $STATUS"
+      sleep 10
+      STATUS=$(checkstatus)
+    done
+  fi >> $log_file 2>&1
+]
+
+rightscale_marker :end

--- a/recipes/wait_for_rackspace.rb
+++ b/recipes/wait_for_rackspace.rb
@@ -29,7 +29,7 @@ log "wait_for_rackspace logs are found in /var/log/wait_for_rackspace.log"
     checkstatus(){ xenstore-read vm-data/user-metadata/rackconnect_automation_status;}
     STATUS=$(checkstatus)
     echo "*** current rackconnect status: $STATUS"
-    while  [ "$STATUS" != "DEPLOYED" ]; do
+    while  [ "$STATUS" != '"DEPLOYED"' ]; do
       echo '*** waiting for rackconnect post boot scripts to complete'
       echo "*** current status: $STATUS"
       sleep 10
@@ -43,7 +43,7 @@ log "wait_for_rackspace logs are found in /var/log/wait_for_rackspace.log"
     checkstatus(){ xenstore-read vm-data/user-metadata/rax_service_level_automation;}
     STATUS=$(checkstatus)
     echo "*** current managed status: $STATUS"
-    while [ "$STATUS" != "Complete" ]; do
+    while [ "$STATUS" != '"Complete"' ]; do
       echo '*** waiting for rackspace post install to complete'
       echo "*** current status: $STATUS"
       sleep 10


### PR DESCRIPTION
xenstore-ls vm-data gives you a ton of information, so you don't have to
pass in anything for the region.

The vm-data/provider_data/roles will tell you if the server is
going to be rackconnected and if it is going to have the rackspace
managed operations stuff added.

expr "$(xenstore-read vm-data/provider_data/roles)" : "rax_managed"
expr "$(xenstore-read vm-data/provider_data/roles)" : "rack_connect"

The above statements will check if the servers are going to be
rackconnected or if they will have the rackspace managed operations
automation run on them, in which case rightscale stuff should wait for
them to finish.

This should return the equivalent data from querying the metadata
server:

xenstore-read vm-data/user-metadata/rackconnect_automation_status

This should provide information about the server finishing its managed
automation scripts:

xenstore-read vm-data/user-metadata/rax_service_level_automation
